### PR TITLE
Python 3 compatibility - `routines/testing.py`

### DIFF
--- a/deepmedic/routines/testing.py
+++ b/deepmedic/routines/testing.py
@@ -6,6 +6,7 @@
 # or read the terms at https://opensource.org/licenses/BSD-3-Clause.
 
 from __future__ import absolute_import, print_function, division
+from six.moves import xrange
 
 import time
 import numpy as np


### PR DESCRIPTION
`xrange` function calls in file `deepmedic/routines/testing.py` didn't work with Python 3. Added `from six.moves import xrange` to resolve the issue.